### PR TITLE
Create new creep to build structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # screeps
+
 My screeps scripts

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,23 @@ Our new creep won’t move until we define the behavior for the role builder.
 
 // Game.spawns['Spawn1'].spawnCreep( [WORK,WORK,WORK,WORK,CARRY,MOVE,MOVE], 'HarvesterBig', { memory: { role: 'harvester' } } );
 
+/*
+
+The Controller upgrade gives access to some new structures: walls, ramparts, and extensions. We’ll discuss walls and ramparts in the next Tutorial section, for now let’s talk about extensions.
+
+Extensions are required to build larger creeps. A creep with only one body part of one type works poorly. Giving it several WORKs will make him work proportionally faster.
+
+However, such a creep will be costly and a lone spawn can only contain 300 energy units. To build creeps costing over 300 energy units you need spawn extensions.
+
+The second Controller level has 5 extensions available for you to build. This number increases with each new level.
+
+You can place extensions at any spot in your room, and a spawn can use them regardless of the distance. In this Tutorial we have already placed corresponding construction sites for your convenience.
+
+
+
+*/
+// Game.spawns['Spawn1'].spawnCreep( [WORK, CARRY, MOVE], 'Builder1', { memory: { role: 'builder' } } );
+
 var roleHarvester = require("role.harvester");
 var roleBuilder = require("role.builder");
 


### PR DESCRIPTION
Let’s create a new creep whose purpose is to build structures. This process will be similar to the previous Tutorial sections. But this time let’s set memory for the new creep right in the method Spawn.spawnCreep by passing it in the third argument.

Spawn a creep with the body [WORK,CARRY,MOVE], the name Builder1, and {role:'builder'} as its memory.
Documentation:
StructureSpawn.spawnCreep