### PR TITLE
Create HarvesterBig creep

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -56,7 +56,15 @@ You can place extensions at any spot in your room, and a spawn can use them rega
 
 /*
 Our new creep won’t move until we define the behavior for the role builder.
+
+Excellent, all the structures are filled with energy. It’s time to build somebody large!
+
 */
+
+
+//Game.spawns['Spawn1'].spawnCreep( [WORK,WORK,WORK,WORK,CARRY,MOVE,MOVE],'HarvesterBig',{ memory: { role: 'harvester' } } );
+
+
 
 var roleHarvester = require('role.harvester');
 var roleBuilder = require('role.builder');


### PR DESCRIPTION
In total, we have 550 energy units in our spawn and extensions. It is enough to build a creep with the body [WORK,WORK,WORK,WORK,CARRY,MOVE,MOVE]. This creep will work 4 times faster than a regular worker creep. Its body is heavier, so we’ll add another MOVE to it. However, two parts are still not enough to move it at the speed of a small fast creep which would require 4xMOVEs or building a road.

Spawn a creep with the body [WORK,WORK,WORK,CARRY,MOVE,MOVE], the name HarvesterBig, and harvester role.