### PR TITLE
Usage of StructureSpawn.renewCreep

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -101,6 +101,12 @@ Creep.suicide
 
 As you can see from the console, after we lacked one harvester, the spawn instantly started building a new one with a new name.
 
+
+
+
+Apart from creating new creeps after the death of old ones, there is another way to maintain the needed number of creeps: the method StructureSpawn.renewCreep. Creep aging is disabled in the Tutorial, so we recommend that you familiarize yourself with it on your own.
+
+
 */
 
 var roleHarvester = require('role.harvester');


### PR DESCRIPTION
Now the memory of the deceased is relegated to oblivion which saves us resources.

Apart from creating new creeps after the death of old ones, there is another way to maintain the needed number of creeps: the method StructureSpawn.renewCreep. Creep aging is disabled in the Tutorial, so we recommend that you familiarize yourself with it on your own.

Documentation:
StructureSpawn.renewCreep