### PR TITLE
Repair damaged structures

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -161,8 +161,6 @@ The enemy creep is eliminated and our colony can breathe easy. However, the inva
 
 */
 
-
-
 var roleHarvester = require("role.harvester");
 var roleUpgrader = require("role.upgrader");
 var roleBuilder = require("role.builder");
@@ -170,6 +168,15 @@ var roleBuilder = require("role.builder");
 module.exports.loop = function() {
   var tower = Game.getObjectById("6222b1f9532e9deb3b312fa0");
   if (tower) {
+
+    var closestDamagedStructure = tower.pos.findClosestByRange(FIND_STRUCTURES, {
+      filter: (structure) => structure.hits < structure.hitsMax
+    });
+    if(closestDamagedStructure) {
+      tower.repair(closestDamagedStructure);
+    }
+
+
     var closestHostile = tower.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
     if (closestHostile) {
       tower.attack(closestHostile);


### PR DESCRIPTION
Damaged structures can be repaired by both creeps and towers. Let’s try to use a tower for that. We’ll need the method repair. You will also need the method Room.find and a filter to locate the damaged walls.

Note that since walls don’t belong to any player, finding them requires the constant FIND_STRUCTURES rather than FIND_MY_STRUCTURES.

Repair all the damaged walls.
Documentation:
Room.find
StructureTower.repair